### PR TITLE
Extract backpressure into it's own pump. Add backpressure_with_relief_valve 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,26 @@
+name: "Test Suite"
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: cargo test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo test --all-features
+
+  # Check formatting with rustfmt
+  formatting:
+    name: cargo fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Ensure rustfmt is installed and setup problem matcher
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt
+      - name: Rustfmt Check
+        uses: actions-rust-lang/rustfmt@v1

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -12,17 +12,12 @@ use futures::{
 /// ```rust
 /// use pumps::Concurrency;
 ///
-/// // define a concurrent operation with 10 concurrent futures with backpressure of 100
-/// let concurrency = Concurrency::concurrent_ordered(10).backpressure(100);
+/// // define a concurrent operation with 10 concurrent futures that retains order
+/// let concurrency = Concurrency::concurrent_ordered(10);
 /// ```
 pub struct Concurrency {
     /// How many futures can be run concurrently in the configured operation
     pub concurrency: usize,
-    /// How many future results can be stored in memory before a consumer receives them from the output channel.
-    /// In other words, this is the size of the output channel.
-    /// When the output channel is full, the operation will stop processing additioanl data
-    /// Defaults to the concurrency number
-    pub backpressure: usize,
     /// whether to preserve the order of the input stream
     pub preserve_order: bool,
 }
@@ -32,7 +27,6 @@ impl Concurrency {
     pub fn concurrent_unordered(concurrency: usize) -> Self {
         Self {
             concurrency,
-            backpressure: concurrency,
             preserve_order: false,
         }
     }
@@ -41,7 +35,6 @@ impl Concurrency {
     pub fn concurrent_ordered(concurrency: usize) -> Self {
         Self {
             concurrency,
-            backpressure: concurrency,
             preserve_order: true,
         }
     }
@@ -50,17 +43,7 @@ impl Concurrency {
     pub fn serial() -> Self {
         Self {
             concurrency: 1,
-            backpressure: 1,
             preserve_order: true,
-        }
-    }
-
-    /// How many futures can be stored in memory before a consumer takes them from the output channel
-    /// (default = concurrency)
-    pub fn backpressure(self, backpressure: usize) -> Self {
-        Self {
-            backpressure,
-            ..self
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,9 +21,10 @@
 //! # async fn save_to_db(json: String) -> String { json }
 //! # let urls:Vec<String> = Vec::new();
 //! let (mut output_receiver, join_handle) = Pipeline::from_iter(urls)
-//!     .map(get_json, Concurrency::concurrent_ordered(5).backpressure(100))
+//!     .map(get_json, Concurrency::concurrent_ordered(5))
+//!     .backpressure(100)
 //!     .map(download_heavy_resource, Concurrency::serial())
-//!     .filter_map(run_algorithm, Concurrency::concurrent_unordered(5).backpressure(10))
+//!     .filter_map(run_algorithm, Concurrency::concurrent_unordered(5))
 //!     .map(save_to_db, Concurrency::concurrent_unordered(100))
 //!     .build();
 //!
@@ -97,11 +98,11 @@
 //!
 //! #### Backpressure
 //!
-//! Backpressure defines the amount of unconsumed data can accumulate in memory. Without back pressure an eger operation will keep processing data and storing it in memory. A slow downstream consumer will result with unbounded memory usage.
+//! Backpressure defines the amount of unconsumed data that can accumulate in memory. Without backpressure an eger operation will keep processing data and storing it in memory. A slow downstream consumer will result with unbounded memory usage. On the other hand, if we limit the in-memory buffering to 1, slow downstream consumer will often hang processing and introduce inefficiencies to the pipeline.
+//! By default, the output channels of the various supplied pumps are with buffer size 1. Adding backpressure before potentially slow operations can improve processing efficiency.
 //!
-//! The `.backpressure(n)` definition limits the output channel of a `Pump` allowing it to stop processing data until the output channel have been consumed.
-//!
-//! The default backpressure is equal to the concurrency number
+//! The `.backpressure(n)` operation limits the output channel of a `Pump` allowing it to stop processing data until the output channel have been consumed.
+//! The `.backpressure_with_relief_valve(n)` operation is similar to `backpressure(n)` but instead of blocking the input channel it drops the oldest inputs.
 
 mod concurrency;
 mod concurrency_base;

--- a/src/pumps/backpressure.rs
+++ b/src/pumps/backpressure.rs
@@ -1,0 +1,147 @@
+use tokio::{
+    sync::mpsc::{self, Receiver},
+    task::JoinHandle,
+};
+
+use crate::Pump;
+
+pub struct Backpressure {
+    pub(crate) n: usize,
+}
+
+impl<In> Pump<In, In> for Backpressure
+where
+    In: Send + 'static,
+{
+    fn spawn(self, mut input_receiver: Receiver<In>) -> (Receiver<In>, JoinHandle<()>) {
+        // pipe channel(?) to channel(n)
+        // for example, if ? = 1, we'll get buffering of n elements
+        let (output_sender, output_receiver) = mpsc::channel::<In>(self.n);
+
+        let h = tokio::spawn(async move {
+            while let Some(input) = input_receiver.recv().await {
+                if let Err(_) = output_sender.send(input).await {
+                    break;
+                }
+            }
+        });
+
+        (output_receiver, h)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::time::Duration;
+    use tokio::sync::mpsc;
+
+    #[tokio::test]
+    async fn backpressure_buffers_1_input_at_a_time() {
+        let (input_sender, input_receiver) = mpsc::channel(1);
+
+        let (mut output_receiver, join_handle) = crate::Pipeline::from(input_receiver)
+            .backpressure(3)
+            .build();
+
+        input_sender.send(1).await.unwrap();
+        assert_eq!(output_receiver.recv().await, Some(1));
+
+        input_sender.send(2).await.unwrap();
+        assert_eq!(output_receiver.recv().await, Some(2));
+
+        input_sender.send(3).await.unwrap();
+        assert_eq!(output_receiver.recv().await, Some(3));
+
+        drop(input_sender);
+
+        assert_eq!(output_receiver.recv().await, None);
+
+        join_handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn backpressure_buffers_less_from_given_n() {
+        let (input_sender, input_receiver) = mpsc::channel(1);
+
+        let (mut output_receiver, join_handle) = crate::Pipeline::from(input_receiver)
+            .backpressure(3)
+            .build();
+
+        input_sender.send(1).await.unwrap();
+        input_sender.send(2).await.unwrap();
+
+        assert_eq!(output_receiver.recv().await, Some(1));
+        assert_eq!(output_receiver.recv().await, Some(2));
+
+        drop(input_sender);
+
+        assert_eq!(output_receiver.recv().await, None);
+
+        join_handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn backpressure_buffers_n_inputs_while_not_consumed() {
+        let (input_sender, input_receiver) = mpsc::channel(1);
+
+        let (mut output_receiver, join_handle) = crate::Pipeline::from(input_receiver)
+            .backpressure(2)
+            .build();
+
+        async fn wait_for_capacity(sender: &mpsc::Sender<i32>) -> usize {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            sender.capacity()
+        }
+
+        input_sender.send(1).await.unwrap(); // this arrives to the output channel
+        assert_eq!(wait_for_capacity(&input_sender).await, 1);
+
+        input_sender.send(2).await.unwrap(); // buffers
+        assert_eq!(wait_for_capacity(&input_sender).await, 1);
+
+        input_sender.send(3).await.unwrap(); // buffers
+        assert_eq!(wait_for_capacity(&input_sender).await, 1);
+
+        input_sender.send(4).await.unwrap(); // stays in input_receiver
+        assert_eq!(wait_for_capacity(&input_sender).await, 0);
+
+        assert_eq!(output_receiver.recv().await, Some(1));
+        assert_eq!(output_receiver.recv().await, Some(2));
+        assert_eq!(output_receiver.recv().await, Some(3));
+        assert_eq!(output_receiver.recv().await, Some(4));
+
+        drop(input_sender);
+
+        assert_eq!(output_receiver.recv().await, None);
+
+        join_handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn backpressure_buffers_vecates_when_consumed() {
+        let (input_sender, input_receiver) = mpsc::channel(1);
+
+        let (mut output_receiver, join_handle) = crate::Pipeline::from(input_receiver)
+            .backpressure(2)
+            .build();
+
+        input_sender.send(1).await.unwrap();
+        input_sender.send(2).await.unwrap();
+        input_sender.send(3).await.unwrap();
+        input_sender.send(4).await.unwrap(); // buffer is full
+
+        assert_eq!(output_receiver.recv().await, Some(1));
+
+        input_sender.send(5).await.unwrap(); // can send thanks to the consumed 1
+        assert_eq!(output_receiver.recv().await, Some(2));
+        assert_eq!(output_receiver.recv().await, Some(3));
+        assert_eq!(output_receiver.recv().await, Some(4));
+        assert_eq!(output_receiver.recv().await, Some(5));
+
+        drop(input_sender);
+
+        assert_eq!(output_receiver.recv().await, None);
+
+        join_handle.await.unwrap();
+    }
+}

--- a/src/pumps/backpressure_with_relief_valve.rs
+++ b/src/pumps/backpressure_with_relief_valve.rs
@@ -1,0 +1,141 @@
+use std::collections::VecDeque;
+
+use futures::FutureExt;
+use tokio::{
+    sync::mpsc::{self, Receiver},
+    task::JoinHandle,
+};
+
+use crate::Pump;
+
+pub struct BackpressureWithReliefValve {
+    pub(crate) n: usize,
+}
+
+impl<In> Pump<In, In> for BackpressureWithReliefValve
+where
+    In: Send + 'static,
+{
+    fn spawn(self, mut input_receiver: Receiver<In>) -> (Receiver<In>, JoinHandle<()>) {
+        let (output_sender, output_receiver) = mpsc::channel::<In>(1);
+
+        let mut buffer = VecDeque::with_capacity(self.n);
+
+        let h = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    biased;
+
+                    output_res = output_sender.reserve().then(|_| {
+                        let front = buffer.pop_front().expect("buffer is not empty");
+                        output_sender.send(front)
+                    }), if !buffer.is_empty() => {
+                        if output_res.is_err() {
+                            break;
+                        }
+                    }
+
+                    input_res = input_receiver.recv() => {
+                        match input_res {
+                            Some(input) =>  {
+                                buffer.push_back(input);
+                                if buffer.len() >= self.n {
+                                    buffer.pop_front();
+                                }
+                            },
+                            None => break,
+                        }
+                    },
+                }
+            }
+        });
+
+        (output_receiver, h)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use tokio::sync::mpsc;
+
+    #[tokio::test]
+    async fn backpressure_with_relief_valve_drops_old_inputs_from_the_start() {
+        let (input_sender, input_receiver) = mpsc::channel(1);
+
+        let (mut output_receiver, join_handle) = crate::Pipeline::from(input_receiver)
+            .backpressure_with_relief_valve(2)
+            .build();
+
+        input_sender.send(1).await.unwrap(); // goes to output channel
+        input_sender.send(2).await.unwrap(); // buffers, than dropped
+        input_sender.send(3).await.unwrap(); // buffers
+        input_sender.send(4).await.unwrap(); // buffers
+
+        assert_eq!(output_receiver.recv().await, Some(1));
+        assert_eq!(output_receiver.recv().await, Some(3));
+        assert_eq!(output_receiver.recv().await, Some(4));
+
+        drop(input_sender);
+
+        assert_eq!(output_receiver.recv().await, None);
+
+        join_handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn backpressure_with_relief_valve_drops_old_inputs() {
+        let (input_sender, input_receiver) = mpsc::channel(1);
+
+        let (mut output_receiver, join_handle) = crate::Pipeline::from(input_receiver)
+            .backpressure_with_relief_valve(2)
+            .build();
+
+        input_sender.send(1).await.unwrap();
+        assert_eq!(output_receiver.recv().await, Some(1));
+
+        input_sender.send(2).await.unwrap(); // goes to output channel
+        input_sender.send(3).await.unwrap(); // buffers then dropped
+        input_sender.send(4).await.unwrap(); // buffers then dropped
+        input_sender.send(5).await.unwrap(); // buffers
+        input_sender.send(6).await.unwrap(); // buffers
+
+        assert_eq!(output_receiver.recv().await, Some(2));
+        assert_eq!(output_receiver.recv().await, Some(5));
+        assert_eq!(output_receiver.recv().await, Some(6));
+
+        drop(input_sender);
+
+        assert_eq!(output_receiver.recv().await, None);
+
+        join_handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn backpressure_with_relief_valve_consumer_keeps_up() {
+        let (input_sender, input_receiver) = mpsc::channel(1);
+
+        let (mut output_receiver, join_handle) = crate::Pipeline::from(input_receiver)
+            .backpressure_with_relief_valve(2)
+            .build();
+
+        input_sender.send(1).await.unwrap(); // goes to output channel
+        input_sender.send(2).await.unwrap(); // buffers
+        input_sender.send(3).await.unwrap(); // buffers
+
+        assert_eq!(output_receiver.recv().await, Some(1));
+        assert_eq!(output_receiver.recv().await, Some(2)); // 3 is in output channel now
+
+        input_sender.send(4).await.unwrap(); // buffers
+        input_sender.send(5).await.unwrap(); // buffers
+
+        assert_eq!(output_receiver.recv().await, Some(3));
+        assert_eq!(output_receiver.recv().await, Some(4));
+        assert_eq!(output_receiver.recv().await, Some(5));
+
+        drop(input_sender);
+
+        assert_eq!(output_receiver.recv().await, None);
+
+        join_handle.await.unwrap();
+    }
+}

--- a/src/pumps/mod.rs
+++ b/src/pumps/mod.rs
@@ -1,3 +1,5 @@
+pub(crate) mod backpressure;
+pub(crate) mod backpressure_with_relief_valve;
 pub(crate) mod enumerate;
 pub(crate) mod filter_map;
 pub(crate) mod flatten;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -115,6 +115,7 @@ impl FutureTimings {
         }
     }
 
+    #[allow(unused)]
     pub async fn debug(&self) {
         let timings = self.0.lock().await;
 


### PR DESCRIPTION
- Refactor backpressure out of concurrency config, into it's own pump
- Add backpressure_with_relief_valve
- add test workflow