### PR TITLE
Add pipeline context

### DIFF
--- a/examples/maze.rs
+++ b/examples/maze.rs
@@ -44,7 +44,7 @@ async fn main() {
     let (mut output_receiver, _h) = Pipeline::from_iter(1..=25)
         .map(
             // Make some moves
-            |x| async move { x % 3 },
+            |x, _| async move { x % 3 },
             Concurrency::concurrent_unordered(3),
         )
         .pump(StatePump {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,16 +9,17 @@
 //! - Eager - work is done before downstream methods consumes it
 //! - Builds on top of Rust async tools as tasks and channels.
 //! - For now only supports the Tokio async runtime
+//! - Supports shared state via [`Pipeline::with_context`]
 //!
 //! Example:
 //!
 //! ```rust
 //! use pumps::{Pipeline, Concurrency};
 //! # tokio::runtime::Runtime::new().unwrap().block_on(async {
-//! # async fn get_json(url: String) -> String { url }
-//! # async fn download_heavy_resource(json: String) -> String { json }
-//! # async fn run_algorithm(json: String) -> Option<String> { Some(json) }
-//! # async fn save_to_db(json: String) -> String { json }
+//! # async fn get_json(url: String, _ctx: ()) -> String { url }
+//! # async fn download_heavy_resource(json: String, _ctx: ()) -> String { json }
+//! # async fn run_algorithm(json: String, _ctx: ()) -> Option<String> { Some(json) }
+//! # async fn save_to_db(json: String, _ctx: ()) -> String { json }
 //! # let urls:Vec<String> = Vec::new();
 //! let (mut output_receiver, join_handle) = Pipeline::from_iter(urls)
 //!     .map(get_json, Concurrency::concurrent_ordered(5))
@@ -112,7 +113,7 @@
 //!
 //! # tokio::runtime::Runtime::new().unwrap().block_on(async {
 //! let (mut output, h) = Pipeline::from_iter(vec![1, 2, 3])
-//!     .map(|x| async move { panic!("oh no") }, Concurrency::serial())
+//!     .map(|x, _| async move { panic!("oh no") }, Concurrency::serial())
 //!     .build();
 //!
 //! assert_eq!(output.recv().await, None);


### PR DESCRIPTION
A bit more interesting than #9 and #10.
This is a breaking change, as the function passed to `map` now takes two arguments.

This PR adds a "context" field to `Pipeline`, allowing us to use shared state without repetitive cloning:

```rust
// We have to clone _twice_ for every call to map().
//
// The function passed to `map()` takes ownership once,
// and the future that function returns takes ownership again.
let c = config.clone();
let a = args.clone();
let x = client.clone();


let mut pipe = Pipeline::from_iter(domains)
	.map(
		move |x| {
			let config = c.clone();
			let args = a.clone();
			let client = x.clone();
			async move {
				// ...do work...
			}
		},
		Concurrency::concurrent_unordered(5),
	)
```

`with_context` lets us write the above like this:

```rust
// Arc is optional
let ctx = Arc::new(ContextStruct { /* ...fields... */ })

let mut pipe = Pipeline::from_iter(domains)
	.with_context(ctx)
	.map(
		|x, ctx| async move {
			// ...do work...
		},
		Concurrency::concurrent_unordered(5),
	)
```

As always, see docstrings for more details.